### PR TITLE
Parse response ignoring echo and init messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,9 @@ bin
 *.war
 *.ear
 
-# Eclipse files #
+# IDE files #
 .settings
 .project
 .classpath
+.idea
+*.iml

--- a/src/main/java/pt/lighthouselabs/obd/commands/ObdCommand.java
+++ b/src/main/java/pt/lighthouselabs/obd/commands/ObdCommand.java
@@ -153,6 +153,13 @@ public abstract class ObdCommand {
      * processing..
      */
     rawData = res.toString().trim();
+
+    /*
+     * Data may have echo or informative text like "INIT BUS..." or similar.
+     * The response ends with two carriage return characters. So we need to take
+     * everything from the last carriage return before those two (trimmed above).
+     */
+    rawData = rawData.substring(rawData.lastIndexOf(13) + 1);
   }
 
   /**

--- a/src/test/java/pt/lighthouselabs/obd/commands/ExtraMessagesTest.java
+++ b/src/test/java/pt/lighthouselabs/obd/commands/ExtraMessagesTest.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package pt.lighthouselabs.obd.commands;
+
+import static org.powermock.api.easymock.PowerMock.*;
+import static org.testng.Assert.assertEquals;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Test results with echo on and off.
+ */
+@PrepareForTest(InputStream.class)
+public class ExtraMessagesTest {
+
+  private SpeedObdCommand command;
+  private InputStream mockIn;
+
+  /**
+   * @throws Exception
+   */
+  @BeforeMethod
+  public void setUp() throws Exception {
+    command = new SpeedObdCommand();
+  }
+
+  /**
+   * Test for valid InputStream read with echo
+   *
+   * @throws java.io.IOException
+   */
+  @Test
+  public void testValidSpeedMetricWithMessage() throws IOException {
+    // mock InputStream read
+    mockIn = createMock(InputStream.class);
+    mockIn.read();
+    expectLastCall().andReturn((byte) 'B');
+    expectLastCall().andReturn((byte) 'U');
+    expectLastCall().andReturn((byte) 'S');
+    expectLastCall().andReturn((byte) ' ');
+    expectLastCall().andReturn((byte) 'I');
+    expectLastCall().andReturn((byte) 'N');
+    expectLastCall().andReturn((byte) 'I');
+    expectLastCall().andReturn((byte) 'T');
+    expectLastCall().andReturn((byte) '.');
+    expectLastCall().andReturn((byte) '.');
+    expectLastCall().andReturn((byte) '.');
+    expectLastCall().andReturn((byte) 13);
+    expectLastCall().andReturn((byte) '4');
+    expectLastCall().andReturn((byte) '1');
+    expectLastCall().andReturn((byte) ' ');
+    expectLastCall().andReturn((byte) '0');
+    expectLastCall().andReturn((byte) 'D');
+    expectLastCall().andReturn((byte) ' ');
+    expectLastCall().andReturn((byte) '4');
+    expectLastCall().andReturn((byte) '0');
+    expectLastCall().andReturn((byte) '>');
+
+    replayAll();
+
+    // call the method to test
+    command.readResult(mockIn);
+    command.getFormattedResult();
+    assertEquals(command.getMetricSpeed(), 64);
+
+    verifyAll();
+  }
+
+  /**
+   * Test for valid InputStream read with echo
+   *
+   * @throws java.io.IOException
+   */
+  @Test
+  public void testValidSpeedMetricWithoutMessage() throws IOException {
+    // mock InputStream read
+    mockIn = createMock(InputStream.class);
+    mockIn.read();
+    expectLastCall().andReturn((byte) '4');
+    expectLastCall().andReturn((byte) '1');
+    expectLastCall().andReturn((byte) ' ');
+    expectLastCall().andReturn((byte) '0');
+    expectLastCall().andReturn((byte) 'D');
+    expectLastCall().andReturn((byte) ' ');
+    expectLastCall().andReturn((byte) '4');
+    expectLastCall().andReturn((byte) '0');
+    expectLastCall().andReturn((byte) '>');
+
+    replayAll();
+
+    // call the method to test
+    command.readResult(mockIn);
+    command.getFormattedResult();
+    assertEquals(command.getMetricSpeed(), 64);
+
+    verifyAll();
+  }
+
+}


### PR DESCRIPTION
I've modified the parsing of responses to ignore any echo or init message that appear before the actual response. This makes possible to use the commands with or without echo enabled and to ignore bus startup messages that might otherwise cause errors.

This is related to: https://github.com/pires/android-obd-reader/issues/16

Can someone review this and let me know if it makes sense?
