### PR TITLE
more efficient string building for DtcNumberObdCommand

### DIFF
--- a/src/main/java/pt/lighthouselabs/obd/commands/control/DtcNumberObdCommand.java
+++ b/src/main/java/pt/lighthouselabs/obd/commands/control/DtcNumberObdCommand.java
@@ -38,7 +38,7 @@ public class DtcNumberObdCommand extends ObdCommand {
   /**
    * Copy ctor.
    * 
-   * @param other
+   * @param other DtcNumberObdCommand that is to be copied
    */
   public DtcNumberObdCommand(DtcNumberObdCommand other) {
     super(other);
@@ -54,8 +54,7 @@ public class DtcNumberObdCommand extends ObdCommand {
 
   public String getFormattedResult() {
     final String res = milOn ? "MIL is ON" : "MIL is OFF";
-    return new StringBuilder().append(res).append(codeCount).append(" codes")
-        .toString();
+    return res + codeCount + " codes";
   }
 
   /**


### PR DESCRIPTION
Android Studio showed a lint warning on this line so I fixed it to be a little more efficient at appending strings. Have you thought of pulling all these strings into a string resource file so it can be internationalized? Just a suggestion. Thanks for the great work and enjoy the change even though its a small one.
