### PR TITLE
Fix for android-obd-reader issue #37

### DIFF
--- a/src/main/java/pt/lighthouselabs/obd/commands/fuel/FindFuelTypeObdCommand.java
+++ b/src/main/java/pt/lighthouselabs/obd/commands/fuel/FindFuelTypeObdCommand.java
@@ -47,7 +47,11 @@ public class FindFuelTypeObdCommand extends ObdCommand {
 
   @Override
   public String getFormattedResult() {
-    return FuelType.fromValue(fuelType).getDescription();
+    try {
+      return FuelType.fromValue(fuelType).getDescription();
+    } catch(Exception e) {
+      return "-";
+    }
   }
 
   @Override


### PR DESCRIPTION
If the fuel type is not found in the FuelType enum a NullPointerException will be returned and
the application will crash. Use a try-catch block to catch the exception and return "-" instead.
