### PR TITLE
Instead of adding a CR to the end of the command every time, just add it...

### DIFF
--- a/src/main/java/pt/lighthouselabs/obd/commands/ObdCommand.java
+++ b/src/main/java/pt/lighthouselabs/obd/commands/ObdCommand.java
@@ -90,11 +90,9 @@ public abstract class ObdCommand {
    */
   protected void sendCommand(OutputStream out) throws IOException,
       InterruptedException {
-    // add the carriage return char
-    cmd += "\r";
-
-    // write to OutputStream (i.e.: a BluetoothSocket)
-    out.write(cmd.getBytes());
+    // write to OutputStream (i.e.: a BluetoothSocket) with an added
+    // Carriage return
+    out.write((cmd + "\r").getBytes());
     out.flush();
 
     /*


### PR DESCRIPTION
... in the executed bytes

This should fix issue #27 and all other problem cases where an OBD command is inited outside a loop and then run consecutively too many times (usually 4-14, depending on adapter).

The reason was of course that there was a new CR added to the command every time the sendCommand() was run, and by the book a CR always resends the previous OBD command then.