### PR TITLE
Changed MPH format from %.2f to %.0f

### DIFF
--- a/src/main/java/pt/lighthouselabs/obd/commands/SpeedObdCommand.java
+++ b/src/main/java/pt/lighthouselabs/obd/commands/SpeedObdCommand.java
@@ -47,7 +47,7 @@ public class SpeedObdCommand extends ObdCommand implements SystemOfUnits {
    * @return a {@link java.lang.String} object.
    */
   public String getFormattedResult() {
-    return useImperialUnits ? String.format("%.2f%s", getImperialUnit(), "mph")
+    return useImperialUnits ? String.format("%.0f%s", getImperialUnit(), "mph")
         : String.format("%d%s", getMetricSpeed(), "km/h");
   }
 


### PR DESCRIPTION
This will help in the android app to show the MPH on only one line.  General use for tracking speed in MPH only needs %.0f precision anyway.