### PR TITLE
Added interface for commands which allow the bus to return as soon as…

### DIFF
--- a/src/main/java/com/github/pires/obd/commands/ObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/ObdCommand.java
@@ -1,7 +1,8 @@
 /**
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
- * the License at http://www.apache.org/licenses/LICENSE-2.0
+ * the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/src/main/java/com/github/pires/obd/commands/ObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/ObdCommand.java
@@ -60,7 +60,7 @@ public abstract class ObdCommand {
   public ObdCommand(String command) {
     this.cmd = command;
     this.buffer = new ArrayList<Integer>();
-    if (!(this instanceof ObdProtocolCommand) && !(this instanceof TroubleCodesObdCommand)) {
+    if (this instanceof ReturnAsapCommand) {
       this.cmd += " 1";//speed up
     }
   }

--- a/src/main/java/com/github/pires/obd/commands/ObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/ObdCommand.java
@@ -1,8 +1,7 @@
 /**
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -38,6 +37,8 @@ public abstract class ObdCommand {
   protected boolean useImperialUnits = false;
   protected String rawData = null;
   protected long responseTimeDelay = 200;
+  private long start;
+  private long end;
   /**
    * Error classes to be tested in order
    */
@@ -54,8 +55,7 @@ public abstract class ObdCommand {
   /**
    * Default ctor to use
    *
-   * @param command
-   * the command to send
+   * @param command the command to send
    */
   public ObdCommand(String command) {
     this.cmd = command;
@@ -74,8 +74,7 @@ public abstract class ObdCommand {
   /**
    * Copy ctor.
    *
-   * @param other
-   * the ObdCommand to copy.
+   * @param other the ObdCommand to copy.
    */
   public ObdCommand(ObdCommand other) {
     this(other.cmd);
@@ -93,8 +92,10 @@ public abstract class ObdCommand {
    */
   public void run(InputStream in, OutputStream out) throws IOException,
       InterruptedException {
+    start = System.currentTimeMillis();
     sendCommand(out);
     readResult(in);
+    end = System.currentTimeMillis();
   }
 
   /**
@@ -103,8 +104,7 @@ public abstract class ObdCommand {
    * This method may be overriden in subclasses, such as ObMultiCommand or
    * TroubleCodesObdCommand.
    *
-   * @param out
-   * The output stream.
+   * @param out The output stream.
    * @throws java.io.IOException if any.
    * @throws java.lang.InterruptedException if any.
    */
@@ -164,7 +164,7 @@ public abstract class ObdCommand {
   protected void fillBuffer() {
     rawData = rawData.replaceAll("\\s", ""); //removes all [ \t\n\x0B\f\r]
     rawData = rawData.replaceAll("(BUS INIT)|(BUSINIT)|(\\.)", "");
-    
+
     if (!rawData.matches("([0-9A-F])+")) {
       throw new NonNumericResponseException(rawData);
     }
@@ -274,9 +274,10 @@ public abstract class ObdCommand {
    * @return the OBD command name.
    */
   public abstract String getName();
-  
-    /**
+
+  /**
    * Time the command waits before returning from #sendCommand()
+   *
    * @return delay in ms
    */
   public long getResponseTimeDelay() {
@@ -285,10 +286,28 @@ public abstract class ObdCommand {
 
   /**
    * Time the command waits before returning from #sendCommand()
+   *
    * @param responseTimeDelay
    */
   public void setResponseTimeDelay(long responseTimeDelay) {
     this.responseTimeDelay = responseTimeDelay;
+  }
+
+  //fixme resultunit
+  public long getStart() {
+    return start;
+  }
+
+  public void setStart(long start) {
+    this.start = start;
+  }
+
+  public long getEnd() {
+    return end;
+  }
+
+  public void setEnd(long end) {
+    this.end = end;
   }
 
 }

--- a/src/main/java/com/github/pires/obd/commands/PercentageObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/PercentageObdCommand.java
@@ -17,7 +17,7 @@ package com.github.pires.obd.commands;
  */
 public abstract class PercentageObdCommand extends ObdCommand {
 
-  private float percentage = 0f;
+  protected float percentage = 0f;
 
   /**
    * @param command a {@link java.lang.String} object.

--- a/src/main/java/com/github/pires/obd/commands/ReturnAsapCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/ReturnAsapCommand.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2015 Andreas.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.pires.obd.commands;
+
+/**
+ * These commands can be answered by the bus with known values, so the bus does 
+ * not have to wait for new values to appear until it prints the result
+ * @author Andreas
+ */
+public interface ReturnAsapCommand {
+  
+}

--- a/src/main/java/com/github/pires/obd/commands/ReturnAsapCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/ReturnAsapCommand.java
@@ -1,17 +1,14 @@
-/*
- * Copyright 2015 Andreas.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.github.pires.obd.commands;
 

--- a/src/main/java/com/github/pires/obd/commands/SpeedObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/SpeedObdCommand.java
@@ -17,7 +17,7 @@ import com.github.pires.obd.enums.AvailableCommandNames;
 /**
  * Current speed.
  */
-public class SpeedObdCommand extends ObdCommand implements SystemOfUnits {
+public class SpeedObdCommand extends ObdCommand implements SystemOfUnits, ReturnAsapCommand {
 
   private int metricSpeed = 0;
 

--- a/src/main/java/com/github/pires/obd/commands/control/DistanceTraveledSinceCodesClearedObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/control/DistanceTraveledSinceCodesClearedObdCommand.java
@@ -54,7 +54,7 @@ public class DistanceTraveledSinceCodesClearedObdCommand extends ObdCommand
 
   @Override
   public float getImperialUnit() {
-    return new Double(km * 0.621371192).floatValue();
+    return Double.valueOf(km * 0.621371192).floatValue();
   }
 
   /**

--- a/src/main/java/com/github/pires/obd/commands/engine/AbsoluteLoadObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/engine/AbsoluteLoadObdCommand.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2015 Andreas.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.github.pires.obd.commands.engine;
+
+import com.github.pires.obd.commands.PercentageObdCommand;
+import com.github.pires.obd.enums.AvailableCommandNames;
+
+/**
+ *
+ * @author Andreas
+ */
+public class AbsoluteLoadObdCommand extends PercentageObdCommand {
+
+  /**
+   * Default ctor.
+   */
+  public AbsoluteLoadObdCommand() {
+    super("01 43");
+  }
+
+  /**
+   * Copy ctor.
+   *
+   * @param other a {@link AbsoluteLoadObdCommand} object.
+   */
+  public AbsoluteLoadObdCommand(AbsoluteLoadObdCommand other) {
+    super(other);
+  }
+
+  @Override
+  protected void performCalculations() {
+    // ignore first two bytes [hh hh] of the response
+    int a = buffer.get(2);
+    int b = buffer.get(3);
+    percentage = (a * 256 + b) * 100 / 255;
+  }
+
+  /**
+   * @return a double.
+   */
+  public double getRatio() {
+    return percentage;
+  }
+
+  @Override
+  public String getName() {
+    return AvailableCommandNames.ABS_LOAD.getValue();
+  }
+
+}

--- a/src/main/java/com/github/pires/obd/commands/engine/AbsoluteLoadObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/engine/AbsoluteLoadObdCommand.java
@@ -1,27 +1,20 @@
-/*
- * Copyright 2015 Andreas.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package com.github.pires.obd.commands.engine;
 
 import com.github.pires.obd.commands.PercentageObdCommand;
 import com.github.pires.obd.enums.AvailableCommandNames;
-
-/**
- *
- * @author Andreas
- */
+ 
 public class AbsoluteLoadObdCommand extends PercentageObdCommand {
 
   /**

--- a/src/main/java/com/github/pires/obd/commands/fuel/FuelTrimObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/fuel/FuelTrimObdCommand.java
@@ -1,7 +1,8 @@
 /**
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
- * the License at http://www.apache.org/licenses/LICENSE-2.0
+ * the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT

--- a/src/main/java/com/github/pires/obd/commands/fuel/FuelTrimObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/fuel/FuelTrimObdCommand.java
@@ -1,8 +1,7 @@
 /**
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
  * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
@@ -25,7 +24,7 @@ public class FuelTrimObdCommand extends ObdCommand {
 
   /**
    * Default ctor.
-   * 
+   *
    * Will read the bank from parameters and construct the command accordingly.
    * Please, see FuelTrim enum for more details.
    *
@@ -34,6 +33,10 @@ public class FuelTrimObdCommand extends ObdCommand {
   public FuelTrimObdCommand(final FuelTrim bank) {
     super(bank.buildObdCommand());
     this.bank = bank;
+  }
+
+  public FuelTrimObdCommand() {
+    this(FuelTrim.SHORT_TERM_BANK_1);
   }
 
   /**

--- a/src/main/java/com/github/pires/obd/enums/AvailableCommandNames.java
+++ b/src/main/java/com/github/pires/obd/enums/AvailableCommandNames.java
@@ -39,7 +39,7 @@ public enum AvailableCommandNames {
   TIMING_ADVANCE("Timing Advance"),
   DTC_NUMBER("Diagnostic Trouble Codes"),
   EQUIV_RATIO("Command Equivalence Ratio"),
-  DISTANCE_TRAVELED_AFTER_CODES_CLEARED("Distance Traveled After Codes Cleared"),
+  DISTANCE_TRAVELED_AFTER_CODES_CLEARED("Distance since codes cleared"),
   CONTROL_MODULE_VOLTAGE("Control Module Power Supply "),
   ENGINE_FUEL_RATE("Engine Fuel Rate"),
   FUEL_RAIL_PRESSURE("Fuel Rail Pressure"),
@@ -48,7 +48,8 @@ public enum AvailableCommandNames {
   TIME_TRAVELED_MIL_ON("Time run with MIL on"),
   TIME_SINCE_TC_CLEARED("Time since trouble codes cleared"),
   REL_THROTTLE_POS("Relative throttle position"),
-  PIDS("Available PIDs");
+  PIDS("Available PIDs"),
+  ABS_LOAD("Absolute load");
 
   private final String value;
 


### PR DESCRIPTION
… a value is present (contrary to commands which require a new value to appear on the bus before return). Implement for speed command only yet, I need to verify which commands support it. Docs are very rare. But the effect is massive speedup (200ms wait delay can be reduced to 80), so its possible to have like real-time speed gauges etc