### PR TITLE
Splittet result unit and value again

### DIFF
--- a/src/main/java/com/github/pires/obd/commands/ObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/ObdCommand.java
@@ -12,8 +12,6 @@
  */
 package com.github.pires.obd.commands;
 
-import com.github.pires.obd.commands.control.TroubleCodesObdCommand;
-import com.github.pires.obd.commands.protocol.ObdProtocolCommand;
 import com.github.pires.obd.exceptions.BusInitException;
 import com.github.pires.obd.exceptions.MisunderstoodCommandException;
 import com.github.pires.obd.exceptions.NoDataException;
@@ -246,7 +244,12 @@ public abstract class ObdCommand {
    * @return a formatted command response in string representation.
    */
   public abstract String getFormattedResult();
-
+  
+ /**
+  * @return the command response in string representation, without formatting.
+  */
+  public abstract String getCalculatedResult();
+  
   /**
    * @return a list of integers
    */
@@ -260,6 +263,14 @@ public abstract class ObdCommand {
   public boolean useImperialUnits() {
     return useImperialUnits;
   }
+  
+  /**
+  * The unit of the result, as used in {@link #getFormattedResult()}
+  * @return a String representing a unit or "", never null  
+  */
+  public String getResultUnit() {
+    return "";//no unit by default
+  } 
 
   /**
    * Set to 'true' if you want to use imperial units, false otherwise. By

--- a/src/main/java/com/github/pires/obd/commands/PercentageObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/PercentageObdCommand.java
@@ -44,7 +44,7 @@ public abstract class PercentageObdCommand extends ObdCommand {
 	 */
   @Override
   public String getFormattedResult() {
-    return String.format("%.1f%s", percentage, "%");
+    return String.format("%.1f%s", percentage, getResultUnit());
   }
 
   /**
@@ -52,6 +52,16 @@ public abstract class PercentageObdCommand extends ObdCommand {
    */
   public float getPercentage() {
     return percentage;
+  }
+  
+  @Override
+  public String getResultUnit() {
+    return "%";
+  }
+  
+  @Override
+  public String getCalculatedResult() {
+    return String.valueOf(percentage);
   }
 
 }

--- a/src/main/java/com/github/pires/obd/commands/PersistentObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/PersistentObdCommand.java
@@ -9,19 +9,7 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
  * License for the specific language governing permissions and limitations under
  * the License.
- */
-/**
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not
- * use this file except in compliance with the License. You may obtain a copy of
- * the License at
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
- * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
- * License for the specific language governing permissions and limitations under
- * the License.
- */
+ */ 
 package com.github.pires.obd.commands;
 
 import java.io.IOException;

--- a/src/main/java/com/github/pires/obd/commands/SpeedObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/SpeedObdCommand.java
@@ -44,14 +44,6 @@ public class SpeedObdCommand extends ObdCommand implements SystemOfUnits, Return
   }
 
   /**
-   * @return a {@link java.lang.String} object.
-   */
-  public String getFormattedResult() {
-    return useImperialUnits ? String.format("%.0f%s", getImperialUnit(), "mph")
-        : String.format("%d%s", getMetricSpeed(), "km/h");
-  }
-
-  /**
    * @return the speed in metric units.
    */
   public int getMetricSpeed() {
@@ -71,7 +63,25 @@ public class SpeedObdCommand extends ObdCommand implements SystemOfUnits, Return
    * @return a float.
    */
   public float getImperialUnit() {
-    return new Double(metricSpeed * 0.621371192).floatValue();
+    return Double.valueOf(metricSpeed * 0.621371192).floatValue();
+  }
+  
+   /**
+   * @return a {@link java.lang.String} object.
+   */
+  public String getFormattedResult() {
+    return useImperialUnits ? String.format("%.2f%s", getImperialUnit(), getResultUnit())
+        : String.format("%d%s", getMetricSpeed(), getResultUnit());
+  }
+
+  @Override
+  public String getCalculatedResult() {
+    return useImperialUnits ? String.valueOf(getImperialUnit()) : String.valueOf(getMetricSpeed());
+  }
+
+  @Override
+  public String getResultUnit() {
+    return useImperialUnits ? "mph" : "km/h";
   }
 
   @Override

--- a/src/main/java/com/github/pires/obd/commands/control/CommandControlModuleVoltageObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/control/CommandControlModuleVoltageObdCommand.java
@@ -56,11 +56,22 @@ public class CommandControlModuleVoltageObdCommand extends ObdCommand {
   }
 
   /**
-	 * 
-	 */
+   * 
+   * @return 
+   */
   @Override
   public String getFormattedResult() {
-    return String.format("%.1f%s", voltage, "V");
+    return String.format("%.1f%s", voltage, getResultUnit());
+  }
+  
+  @Override
+  public String getResultUnit(){
+    return "V";
+  }
+  
+  @Override
+  public String getCalculatedResult(){
+    return String.valueOf(voltage);
   }
 
   /**

--- a/src/main/java/com/github/pires/obd/commands/control/CommandEquivRatioObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/control/CommandEquivRatioObdCommand.java
@@ -13,6 +13,7 @@
 package com.github.pires.obd.commands.control;
 
 import com.github.pires.obd.commands.ObdCommand;
+import com.github.pires.obd.commands.PercentageObdCommand;
 import com.github.pires.obd.enums.AvailableCommandNames;
 
 /**
@@ -26,10 +27,8 @@ import com.github.pires.obd.enums.AvailableCommandNames;
  * equivalence ratio of 0.95, the commanded A/F ratio to the engine would be
  * 14.64 * 0.95 = 13.9 A/F.
  */
-public class CommandEquivRatioObdCommand extends ObdCommand {
+public class CommandEquivRatioObdCommand extends PercentageObdCommand {
 
-  // Equivalent ratio (%)
-  private double ratio = 0.00;
 
   /**
    * Default ctor.
@@ -52,22 +51,15 @@ public class CommandEquivRatioObdCommand extends ObdCommand {
     // ignore first two bytes [hh hh] of the response
     int a = buffer.get(2);
     int b = buffer.get(3);
-    ratio = (a * 256 + b) / 32768;
+    percentage = (a * 256 + b) / 32768;
   }
 
-  /**
-	 * 
-	 */
-  @Override
-  public String getFormattedResult() {
-    return String.format("%.1f%s", ratio, "%");
-  }
 
   /**
    * @return a double.
    */
   public double getRatio() {
-    return ratio;
+    return (double)percentage;
   }
 
   @Override

--- a/src/main/java/com/github/pires/obd/commands/control/DistanceTraveledSinceCodesClearedObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/control/DistanceTraveledSinceCodesClearedObdCommand.java
@@ -47,9 +47,19 @@ public class DistanceTraveledSinceCodesClearedObdCommand extends ObdCommand
     km = buffer.get(2) * 256 + buffer.get(3);
   }
 
-  @Override
   public String getFormattedResult() {
-    return String.format("%.2f%s", (float)km, "km");
+    return useImperialUnits ? String.format("%.2f%s", getImperialUnit(), getResultUnit())
+            : String.format("%d%s", km, getResultUnit());
+  }
+
+  @Override
+  public String getCalculatedResult() {
+    return useImperialUnits ? String.valueOf(getImperialUnit()) : String.valueOf(km);
+  }
+
+  @Override
+  public String getResultUnit() {
+    return useImperialUnits ? "m" : "km";
   }
 
   @Override

--- a/src/main/java/com/github/pires/obd/commands/control/DistanceTraveledWithMILOnObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/control/DistanceTraveledWithMILOnObdCommand.java
@@ -44,11 +44,19 @@ public class DistanceTraveledWithMILOnObdCommand extends ObdCommand
     km = buffer.get(2) * 256 + buffer.get(3);
   }
 
-  @Override
   public String getFormattedResult() {
-    return useImperialUnits
-        ? String.format("%.2f%s", getImperialUnit(), "m")
-        : String.format("%.2f%s", (float) km, "km");
+    return useImperialUnits ? String.format("%.2f%s", getImperialUnit(), getResultUnit())
+            : String.format("%d%s", km, getResultUnit());
+  }
+
+  @Override
+  public String getCalculatedResult() {
+    return useImperialUnits ? String.valueOf(getImperialUnit()) : String.valueOf(km);
+  }
+
+  @Override
+  public String getResultUnit() {
+    return useImperialUnits ? "m" : "km";
   }
 
   @Override
@@ -61,16 +69,6 @@ public class DistanceTraveledWithMILOnObdCommand extends ObdCommand
    */
   public int getKm() {
     return km;
-  }
-
-  /**
-   * <p>
-   * Setter for the field <code>km</code>.</p>
-   *
-   * @param km a int.
-   */
-  public void setKm(int km) {
-    this.km = km;
   }
 
   @Override

--- a/src/main/java/com/github/pires/obd/commands/control/DtcNumberObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/control/DtcNumberObdCommand.java
@@ -60,6 +60,11 @@ public class DtcNumberObdCommand extends ObdCommand {
     return new StringBuilder().append(res).append(codeCount).append(" codes")
         .toString();
   }
+  
+  @Override
+  public String getCalculatedResult() {
+    return String.valueOf(codeCount);
+  }
 
   /**
    * @return the number of trouble codes currently flaggd in the ECU.

--- a/src/main/java/com/github/pires/obd/commands/control/TroubleCodesObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/control/TroubleCodesObdCommand.java
@@ -105,10 +105,17 @@ public class TroubleCodesObdCommand extends ObdCommand {
 
   /**
    * @return the formatted result of this command in string representation.
+   * @deprecated use #getCalculatedResult instead
    */
   public String formatResult() {
     return codes.toString();
   }
+  
+  @Override
+  public String getCalculatedResult() {
+    return String.valueOf(codes);
+  }
+
 
   @Override
   protected void readRawData(InputStream in) throws IOException {

--- a/src/main/java/com/github/pires/obd/commands/control/VinObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/control/VinObdCommand.java
@@ -61,6 +61,11 @@ public class VinObdCommand extends PersistentObdCommand {
   public String getName() {
     return AvailableCommandNames.VIN.getValue();
   }
+  
+  @Override
+  public String getCalculatedResult() {
+    return String.valueOf(vin);
+  }
 
 }
 

--- a/src/main/java/com/github/pires/obd/commands/engine/EngineFuelRate.java
+++ b/src/main/java/com/github/pires/obd/commands/engine/EngineFuelRate.java
@@ -60,7 +60,17 @@ public class EngineFuelRate extends ObdCommand {
 	 */
   @Override
   public String getFormattedResult() {
-    return String.format("%.1f%s", fuelrate, "L/h");
+    return String.format("%.1f%s", fuelrate, getResultUnit());
+  }
+  
+  @Override
+  public String getCalculatedResult() {
+    return String.valueOf(fuelrate);
+  }
+
+  @Override
+  public String getResultUnit() {
+    return "L/h";
   }
 
   /**

--- a/src/main/java/com/github/pires/obd/commands/engine/EngineRPMObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/engine/EngineRPMObdCommand.java
@@ -49,7 +49,17 @@ public class EngineRPMObdCommand extends ObdCommand {
    */
   @Override
   public String getFormattedResult() {
-    return String.format("%d%s", rpm, " RPM");
+    return String.format("%d%s", rpm, getResultUnit());
+  }
+  
+  @Override
+  public String getCalculatedResult() {
+    return String.valueOf(rpm);
+  }
+
+  @Override
+  public String getResultUnit() {
+    return "RPM";
   }
 
   @Override

--- a/src/main/java/com/github/pires/obd/commands/engine/EngineRuntimeObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/engine/EngineRuntimeObdCommand.java
@@ -52,6 +52,16 @@ public class EngineRuntimeObdCommand extends ObdCommand {
     final String ss = String.format("%02d", value % 60);
     return String.format("%s:%s:%s", hh, mm, ss);
   }
+  
+  @Override
+  public String getCalculatedResult() {
+    return String.valueOf(value);
+  }
+
+  @Override
+  public String getResultUnit() {
+    return "s";
+  }
 
   @Override
   public String getName() {

--- a/src/main/java/com/github/pires/obd/commands/engine/MassAirFlowObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/engine/MassAirFlowObdCommand.java
@@ -46,7 +46,17 @@ public class MassAirFlowObdCommand extends ObdCommand {
 
   @Override
   public String getFormattedResult() {
-    return String.format("%.2f%s", maf, "g/s");
+    return String.format("%.2f%s", maf, getResultUnit());
+  }
+
+  @Override
+  public String getCalculatedResult() {
+    return String.valueOf(maf);
+  }
+
+  @Override
+  public String getResultUnit() {
+    return "g/s";
   }
 
   /**

--- a/src/main/java/com/github/pires/obd/commands/fuel/FindFuelTypeObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/fuel/FindFuelTypeObdCommand.java
@@ -53,6 +53,11 @@ public class FindFuelTypeObdCommand extends ObdCommand {
       return "-";
     }
   }
+  
+  @Override
+  public String getCalculatedResult() {
+    return String.valueOf(fuelType);
+  }
 
   @Override
   public String getName() {

--- a/src/main/java/com/github/pires/obd/commands/fuel/FuelConsumptionRateObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/fuel/FuelConsumptionRateObdCommand.java
@@ -43,7 +43,17 @@ public class FuelConsumptionRateObdCommand extends ObdCommand {
 
   @Override
   public String getFormattedResult() {
-    return String.format("%.1f%s", fuelRate, "");
+    return String.format("%.1f%s", fuelRate, getResultUnit());
+  }
+
+  @Override
+  public String getCalculatedResult() {
+    return String.valueOf(fuelRate);
+  }
+
+  @Override
+  public String getResultUnit() {
+    return "L/h";
   }
 
   /**

--- a/src/main/java/com/github/pires/obd/commands/fuel/FuelEconomyObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/fuel/FuelEconomyObdCommand.java
@@ -59,10 +59,20 @@ public class FuelEconomyObdCommand extends ObdCommand {
         * fuelConsumptionCommand.getLitersPerHour();
   }
 
-  @Override
+ @Override
   public String getFormattedResult() {
     return useImperialUnits ? String.format("%.1f %s", getMilesPerUKGallon(),
-        "mpg") : String.format("%.1f %s", kml, "l/100km");
+            getResultUnit()) : String.format("%.1f %s", kml, getResultUnit());
+  }
+
+  @Override
+  public String getCalculatedResult() {
+    return useImperialUnits ? String.valueOf(getMilesPerUKGallon()) : String.valueOf(kml);
+  }
+
+  @Override
+  public String getResultUnit() {
+    return useImperialUnits ? "mpg" : "l/100km";
   }
 
   /**

--- a/src/main/java/com/github/pires/obd/commands/fuel/FuelLevelObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/fuel/FuelLevelObdCommand.java
@@ -13,14 +13,13 @@
 package com.github.pires.obd.commands.fuel;
 
 import com.github.pires.obd.commands.ObdCommand;
+import com.github.pires.obd.commands.PercentageObdCommand;
 import com.github.pires.obd.enums.AvailableCommandNames;
 
 /**
  * Get fuel level in percentage
  */
-public class FuelLevelObdCommand extends ObdCommand {
-
-  private float fuelLevel = 0f;
+public class FuelLevelObdCommand extends PercentageObdCommand {
 
   public FuelLevelObdCommand() {
     super("01 2F");
@@ -29,14 +28,9 @@ public class FuelLevelObdCommand extends ObdCommand {
   @Override
   protected void performCalculations() {
     // ignore first two bytes [hh hh] of the response
-    fuelLevel = 100.0f * buffer.get(2) / 255.0f;
+    percentage = 100.0f * buffer.get(2) / 255.0f;
   }
-
-  @Override
-  public String getFormattedResult() {
-    return String.format("%.1f%s", fuelLevel, "%");
-  }
-
+  
   @Override
   public String getName() {
     return AvailableCommandNames.FUEL_LEVEL.getValue();
@@ -46,7 +40,7 @@ public class FuelLevelObdCommand extends ObdCommand {
    * @return a float.
    */
   public float getFuelLevel() {
-    return fuelLevel;
+    return percentage;
   }
 
 }

--- a/src/main/java/com/github/pires/obd/commands/fuel/FuelTrimObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/fuel/FuelTrimObdCommand.java
@@ -13,14 +13,14 @@
 package com.github.pires.obd.commands.fuel;
 
 import com.github.pires.obd.commands.ObdCommand;
+import com.github.pires.obd.commands.PercentageObdCommand;
 import com.github.pires.obd.enums.FuelTrim;
 
 /**
  * Fuel Trim.
  */
-public class FuelTrimObdCommand extends ObdCommand {
+public class FuelTrimObdCommand extends PercentageObdCommand {
 
-  private float fuelTrimValue = 0.0f;
   private final FuelTrim bank;
 
   /**
@@ -45,24 +45,20 @@ public class FuelTrimObdCommand extends ObdCommand {
    * @return
    */
   private float prepareTempValue(final int value) {
-    return new Double((value - 128) * (100.0 / 128)).floatValue();
+    return Double.valueOf((value - 128) * (100.0 / 128)).floatValue();
   }
 
   protected void performCalculations() {
     // ignore first two bytes [hh hh] of the response
-    fuelTrimValue = prepareTempValue(buffer.get(2));
-  }
-
-  @Override
-  public String getFormattedResult() {
-    return String.format("%.2f%s", fuelTrimValue, "%");
+    percentage = prepareTempValue(buffer.get(2));
   }
 
   /**
    * @return the readed Fuel Trim percentage value.
+   * @deprecated use #getCalculatedResult()
    */
   public final float getValue() {
-    return fuelTrimValue;
+    return percentage;
   }
 
   /**

--- a/src/main/java/com/github/pires/obd/commands/pressure/PressureObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/pressure/PressureObdCommand.java
@@ -76,7 +76,7 @@ public abstract class PressureObdCommand extends ObdCommand implements
    * @return the pressure in psi
    */
   public float getImperialUnit() {
-    return new Double(pressure * 0.145037738).floatValue();
+    return Double.valueOf(pressure * 0.145037738).floatValue();
   }
   
   @Override

--- a/src/main/java/com/github/pires/obd/commands/pressure/PressureObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/pressure/PressureObdCommand.java
@@ -61,8 +61,8 @@ public abstract class PressureObdCommand extends ObdCommand implements
 
   @Override
   public String getFormattedResult() {
-    return useImperialUnits ? String.format("%.1f%s", getImperialUnit(), "psi")
-        : String.format("%d%s", pressure, "kPa");
+    return useImperialUnits ? String.format("%.1f%s", getImperialUnit(), getResultUnit())
+        : String.format("%d%s", pressure, getResultUnit());
   }
 
   /**
@@ -77,6 +77,16 @@ public abstract class PressureObdCommand extends ObdCommand implements
    */
   public float getImperialUnit() {
     return new Double(pressure * 0.145037738).floatValue();
+  }
+  
+  @Override
+  public String getCalculatedResult() {
+    return useImperialUnits ? String.valueOf(getImperialUnit()) : String.valueOf(pressure);
+  }
+
+  @Override
+  public String getResultUnit() {
+    return useImperialUnits ? "psi" : "kPa";
   }
 
 }

--- a/src/main/java/com/github/pires/obd/commands/protocol/AvailablePidsObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/protocol/AvailablePidsObdCommand.java
@@ -39,13 +39,17 @@ public class AvailablePidsObdCommand extends PersistentObdCommand {
   }
 
   @Override
-  public String getFormattedResult() {
-    return String.valueOf(rawData);
-  }
-
-  @Override
   public String getName() {
     return AvailableCommandNames.PIDS.getValue();
   }
 
+  @Override
+  public String getFormattedResult() {
+    return getCalculatedResult();
+  }
+
+  @Override
+  public String getCalculatedResult() {
+    return String.valueOf(rawData);
+  }
 }

--- a/src/main/java/com/github/pires/obd/commands/protocol/ObdProtocolCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/protocol/ObdProtocolCommand.java
@@ -43,4 +43,9 @@ public abstract class ObdProtocolCommand extends ObdCommand {
     // settings commands don't return a value appropriate to place into the
     // buffer, so do nothing
   }
+  
+  @Override
+  public String getCalculatedResult() {
+    return String.valueOf(getResult());
+  }
 }

--- a/src/main/java/com/github/pires/obd/commands/temperature/TemperatureObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/temperature/TemperatureObdCommand.java
@@ -47,16 +47,28 @@ public abstract class TemperatureObdCommand extends ObdCommand implements
     temperature = buffer.get(2) - 40;
   }
 
+  
   /**
    * {@inheritDoc}
    *
    * Get values from 'buff', since we can't rely on char/string for
    * calculations.
+   * @return 
    */
   @Override
   public String getFormattedResult() {
-    return useImperialUnits ? String.format("%.1f%s", getImperialUnit(), "F")
-        : String.format("%.0f%s", temperature, "C");
+    return useImperialUnits ? String.format("%.1f%s", getImperialUnit(), getResultUnit())
+        : String.format("%.0f%s", temperature, getResultUnit());
+  }
+
+  @Override
+  public String getCalculatedResult() {
+    return useImperialUnits ? String.valueOf(getImperialUnit()) : String.valueOf(temperature);
+  }
+
+  @Override
+  public String getResultUnit() {
+    return useImperialUnits ? "F" : "C";
   }
 
   /**


### PR DESCRIPTION
Changes are: 

- new Double() has been replaced by Double.valueOf as per Javadoc http://docs.oracle.com/javase/7/docs/api/java/lang/Double.html#valueOf(double)
- Unit signs ("%", "km" ... ) are available via getResultUnit()
- getFormattedResult() uses mostly this for formatting, as it was previously
- getCalculatedResult() returns the calculated value without formatting

with this change, the values from the OBD device can be used for plotting graphs etc