### PR TITLE
Add a test to check end of stream reached (i.e. read() returns -1)

### DIFF
--- a/src/main/java/com/github/pires/obd/commands/ObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/ObdCommand.java
@@ -171,9 +171,28 @@ public abstract class ObdCommand {
         byte b = 0;
         StringBuilder res = new StringBuilder();
 
+        // commented by pdalfarr
+        /*
         // read until '>' arrives
         while ((char) (b = (byte) in.read()) != '>') {
             res.append((char) b);
+        }
+        */
+        // fix proposed by pdalfarr
+        char c;
+        while(true)
+        {
+      	  b = (byte) in.read();
+      	  if(b == -1) // -1 if the end of the stream is reached
+      	  {
+      		  break;
+      	  }
+      	  c = (char)b;
+      	  if(c == '>') // read until '>' arrives
+      	  {
+      		  break;
+      	  }
+      	  res.append(c);
         }
 
     /*

--- a/src/main/java/com/github/pires/obd/commands/ObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/ObdCommand.java
@@ -171,14 +171,7 @@ public abstract class ObdCommand {
         byte b = 0;
         StringBuilder res = new StringBuilder();
 
-        // commented by pdalfarr
-        /*
-        // read until '>' arrives
-        while ((char) (b = (byte) in.read()) != '>') {
-            res.append((char) b);
-        }
-        */
-        // fix proposed by pdalfarr
+        // read until '>' arrives OR end of stream reached
         char c;
         while(true)
         {

--- a/src/main/java/com/github/pires/obd/commands/control/TroubleCodesCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/control/TroubleCodesCommand.java
@@ -99,16 +99,7 @@ public class TroubleCodesCommand extends ObdCommand {
         byte b = 0;
         StringBuilder res = new StringBuilder();
 
-        // commented by pdalfarr
-        /*
-        // read until '>' arrives
-        while ((char) (b = (byte) in.read()) != '>') {
-            if ((char) b != ' ') {
-                res.append((char) b);
-            }
-        }
-        */
-        // fix proposed by pdalfarr
+        // read until '>' arrives OR end of stream reached (and skip ' ')
         char c;
         while(true)
         {

--- a/src/main/java/com/github/pires/obd/commands/control/TroubleCodesCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/control/TroubleCodesCommand.java
@@ -99,11 +99,33 @@ public class TroubleCodesCommand extends ObdCommand {
         byte b = 0;
         StringBuilder res = new StringBuilder();
 
+        // commented by pdalfarr
+        /*
         // read until '>' arrives
         while ((char) (b = (byte) in.read()) != '>') {
             if ((char) b != ' ') {
                 res.append((char) b);
             }
+        }
+        */
+        // fix proposed by pdalfarr
+        char c;
+        while(true)
+        {
+      	  b = (byte) in.read();
+      	  if(b == -1) // -1 if the end of the stream is reached
+      	  {
+      		  break;
+      	  }
+      	  c = (char)b;
+      	  if(c == '>') // read until '>' arrives
+      	  {
+      		  break;
+      	  }
+      	  if(c != ' ') // skip ' '
+      	  {
+      		  res.append(c);
+      	  }
         }
 
         rawData = res.toString().trim();


### PR DESCRIPTION
I did this chanes because of endless loops on PC when OBD device is connected to PC, but NOT to the car. (endless loop with read() returning -1)
More generally, checking for end of stream seems quite standard.

Can you please review?

KR,

Pascal