### PR TITLE
Fix TroubleCodesCommand PID and some simplification

### DIFF
--- a/src/main/java/com/github/pires/obd/commands/control/DtcNumberCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/control/DtcNumberCommand.java
@@ -45,8 +45,7 @@ public class DtcNumberCommand extends ObdCommand {
      */
     public String getFormattedResult() {
         final String res = milOn ? "MIL is ON" : "MIL is OFF";
-        return new StringBuilder().append(res).append(codeCount).append(" codes")
-                .toString();
+        return res + codeCount + " codes";
     }
 
     @Override

--- a/src/main/java/com/github/pires/obd/commands/control/VinCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/control/VinCommand.java
@@ -35,7 +35,7 @@ public class VinCommand extends PersistentCommand {
         // ignore first two bytes [01 31] of the response
         StringBuilder b = new StringBuilder();
         for (int i : bufferUse) {
-            b.append(new Character((char) buffer.get(i).intValue()).toString());
+            b.append(Character.toString((char) buffer.get(i).intValue()));
         }
         vin = b.toString().replaceAll("[\u0000-\u001f]", "");
     }

--- a/src/main/java/com/github/pires/obd/commands/protocol/OdbRawCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/protocol/OdbRawCommand.java
@@ -19,7 +19,7 @@ public class OdbRawCommand extends ObdProtocolCommand {
 
     @Override
     public String getName() {
-        return "Custom command " + getName();
+        return "Custom command " + getCommandPID();
     }
 
 }


### PR DESCRIPTION
Simplify string generation into DtcNumberCommand.getFormattedResult(), StringBuilder is redundant for this . Fix command PID and simplify performCalculations() method into class TroubleCodesCommand. Update char to string conversation into VinCommand.performCalculations(). Fix recursion into OdbRawCommand.getName().