### PR TITLE
Added describe protocol commands.

### DIFF
--- a/src/main/java/com/github/pires/obd/commands/protocol/DescribeProtocolCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/protocol/DescribeProtocolCommand.java
@@ -1,0 +1,29 @@
+package com.github.pires.obd.commands.protocol;
+
+import com.github.pires.obd.enums.AvailableCommandNames;
+
+/**
+ * Describe the current Protocol.
+ * If a protocol is chosen and the automatic option is
+ * also selected, AT DP will show the word 'AUTO' before
+ * the protocol description. Note that the description
+ * shows the actual protocol names, not the numbers
+ * used by the protocol setting commands.
+ */
+public class DescribeProtocolCommand extends ObdProtocolCommand {
+
+    public DescribeProtocolCommand() {
+        super("AT DP");
+    }
+
+    @Override
+    public String getFormattedResult() {
+        return getResult();
+    }
+
+    @Override
+    public String getName() {
+        return AvailableCommandNames.DESCRIBE_PROTOCOL.getValue();
+    }
+
+}

--- a/src/main/java/com/github/pires/obd/commands/protocol/DescribeProtocolNumberCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/protocol/DescribeProtocolNumberCommand.java
@@ -1,0 +1,64 @@
+package com.github.pires.obd.commands.protocol;
+
+import com.github.pires.obd.commands.ObdCommand;
+import com.github.pires.obd.enums.AvailableCommandNames;
+import com.github.pires.obd.enums.ObdProtocols;
+
+/**
+ * Describe the Protocol by Number.
+ * It returns a number which represents the current
+ * obdProtocol. If the automatic search function is also
+ * enabled, the number will be preceded with the letter
+ * ‘A’. The number is the same one that is used with the
+ * set obdProtocol and test obdProtocol commands.
+ */
+public class DescribeProtocolNumberCommand extends ObdCommand {
+
+    private ObdProtocols obdProtocol = ObdProtocols.AUTO;
+
+    public DescribeProtocolNumberCommand() {
+        super("AT DPN");
+    }
+
+    /**
+     * This method exists so that for each command, there must be a method that is
+     * called only once to perform calculations.
+     */
+    @Override
+    protected void performCalculations() {
+        String result = getResult();
+        char protocolNumber;
+        if (result.length() == 2) {//the obdProtocol was set automatic and its format A#
+            protocolNumber = result.charAt(1);
+        } else protocolNumber = result.charAt(0);
+        ObdProtocols[] protocols = ObdProtocols.values();
+        for (ObdProtocols protocol : protocols) {
+            if (protocol.getValue() == protocolNumber) {
+                this.obdProtocol = protocol;
+                break;
+            }
+        }
+    }
+
+    @Override
+    public String getFormattedResult() {
+        return getResult();
+    }
+
+    /**
+     * @return the command response in string representation, without formatting.
+     */
+    @Override
+    public String getCalculatedResult() {
+        return obdProtocol.name();
+    }
+
+    @Override
+    public String getName() {
+        return AvailableCommandNames.DESCRIBE_PROTOCOL_NUMBER.getValue();
+    }
+
+    public ObdProtocols getObdProtocol() {
+        return obdProtocol;
+    }
+}

--- a/src/main/java/com/github/pires/obd/enums/AvailableCommandNames.java
+++ b/src/main/java/com/github/pires/obd/enums/AvailableCommandNames.java
@@ -39,14 +39,16 @@ public enum AvailableCommandNames {
     ABS_LOAD("Absolute load"),
     ENGINE_OIL_TEMP("Engine oil temperature"),
     AIR_FUEL_RATIO("Air/Fuel Ratio"),
-    WIDEBAND_AIR_FUEL_RATIO("Wideband Air/Fuel Ratio");
+    WIDEBAND_AIR_FUEL_RATIO("Wideband Air/Fuel Ratio"),
+    DESCRIBE_PROTOCOL("Describe protocol"),
+    DESCRIBE_PROTOCOL_NUMBER("Describe protocol number");
 
     private final String value;
 
     /**
-     * @param value
+     * @param value Command description
      */
-    private AvailableCommandNames(String value) {
+    AvailableCommandNames(String value) {
         this.value = value;
     }
 

--- a/src/test/java/com/github/pires/obd/commands/DescribeProtocolNumberCommandTest.java
+++ b/src/test/java/com/github/pires/obd/commands/DescribeProtocolNumberCommandTest.java
@@ -1,0 +1,81 @@
+package com.github.pires.obd.commands;
+
+import com.github.pires.obd.commands.protocol.DescribeProtocolNumberCommand;
+import com.github.pires.obd.enums.ObdProtocols;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.io.InputStream;
+
+import static org.powermock.api.easymock.PowerMock.*;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Tests for DescribeProtocolNumberCommand class.
+ */
+public class DescribeProtocolNumberCommandTest {
+
+    private DescribeProtocolNumberCommand command;
+    private InputStream mockIn;
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        command = new DescribeProtocolNumberCommand();
+    }
+
+    @Test
+    public void testGetCalculatedResult() throws Exception {
+        mockIn = createMock(InputStream.class);
+        mockIn.read();
+        expectLastCall().andReturn((byte) 'A');
+        expectLastCall().andReturn((byte) '3');
+        expectLastCall().andReturn((byte) '>');
+        expectLastCall().andReturn((byte) '2');
+        expectLastCall().andReturn((byte) '>');
+
+        replayAll();
+
+        // call the method to test
+        command.readResult(mockIn);
+        assertEquals(command.getCalculatedResult(), ObdProtocols.ISO_9141_2.name());//AUTO ISO_9141_2
+
+        // call the method to test
+        command.readResult(mockIn);
+        assertEquals(command.getCalculatedResult(), ObdProtocols.SAE_J1850_VPW.name());//SAE_J1850_VPW
+
+        verifyAll();
+    }
+
+    @Test
+    public void testGetProtocol() throws Exception {
+        mockIn = createMock(InputStream.class);
+        mockIn.read();
+        expectLastCall().andReturn((byte) 'A');
+        expectLastCall().andReturn((byte) '6');
+        expectLastCall().andReturn((byte) '>');
+        expectLastCall().andReturn((byte) '7');
+        expectLastCall().andReturn((byte) '>');
+
+        replayAll();
+
+        // call the method to test
+        command.readResult(mockIn);
+        assertEquals(command.getObdProtocol(), ObdProtocols.ISO_15765_4_CAN);//AUTO ISO_15765_4_CAN
+
+        // call the method to test
+        command.readResult(mockIn);
+        assertEquals(command.getObdProtocol(), ObdProtocols.ISO_15765_4_CAN_B);//ISO_15765_4_CAN_B
+
+        verifyAll();
+    }
+
+    /**
+     * Clear resources.
+     */
+    @AfterClass
+    public void tearDown() {
+        command = null;
+        mockIn = null;
+    }
+}


### PR DESCRIPTION
These commands need to check can we read TroubleCodesCommand or not. I plan add TroubleCodesCommand for CAN (ISO-15765) protocol, now TroubleCodesCommand read only ISO9141-2, KWP2000 Fast and KWP2000 5Kbps (ISO15031) protocols.