### PR TITLE
Boxing and unboxing should not be immediately reversed

### DIFF
--- a/src/main/java/com/github/pires/obd/commands/SpeedCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/SpeedCommand.java
@@ -59,7 +59,7 @@ public class SpeedCommand extends ObdCommand implements SystemOfUnits {
      * @return a float.
      */
     public float getImperialUnit() {
-        return Double.valueOf(metricSpeed * 0.621371192).floatValue();
+        return metricSpeed * 0.621371192F;
     }
 
     /**

--- a/src/main/java/com/github/pires/obd/commands/control/DistanceMILOnCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/control/DistanceMILOnCommand.java
@@ -64,7 +64,7 @@ public class DistanceMILOnCommand extends ObdCommand
     /** {@inheritDoc} */
     @Override
     public float getImperialUnit() {
-        return Double.valueOf(km * 0.621371192).floatValue();
+        return km * 0.621371192F;
     }
 
     /**

--- a/src/main/java/com/github/pires/obd/commands/control/DistanceSinceCCCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/control/DistanceSinceCCCommand.java
@@ -64,7 +64,7 @@ public class DistanceSinceCCCommand extends ObdCommand
     /** {@inheritDoc} */
     @Override
     public float getImperialUnit() {
-        return Double.valueOf(km * 0.621371192).floatValue();
+        return km * 0.621371192F;
     }
 
     /**

--- a/src/main/java/com/github/pires/obd/commands/fuel/FuelTrimCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/fuel/FuelTrimCommand.java
@@ -38,7 +38,7 @@ public class FuelTrimCommand extends PercentageObdCommand {
      * @return
      */
     private float prepareTempValue(final int value) {
-        return Double.valueOf((value - 128) * (100.0 / 128)).floatValue();
+        return (value - 128) * (100.0F / 128);
     }
 
     /**

--- a/src/main/java/com/github/pires/obd/commands/pressure/PressureCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/pressure/PressureCommand.java
@@ -75,7 +75,7 @@ public abstract class PressureCommand extends ObdCommand implements
      * @return the pressure in psi
      */
     public float getImperialUnit() {
-        return Double.valueOf(pressure * 0.145037738).floatValue();
+        return pressure * 0.145037738F;
     }
 
     /** {@inheritDoc} */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2153 - “Boxing and unboxing should not be immediately reversed”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2153
Please let me know if you have any questions.
Ayman Abdelghany.