### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/src/main/java/com/github/pires/obd/commands/ObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/ObdCommand.java
@@ -42,7 +42,7 @@ public abstract class ObdCommand {
      */
     public ObdCommand(String command) {
         this.cmd = command;
-        this.buffer = new ArrayList<Integer>();
+        this.buffer = new ArrayList<>();
     }
 
     /**

--- a/src/main/java/com/github/pires/obd/commands/ObdMultiCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/ObdMultiCommand.java
@@ -19,7 +19,7 @@ public class ObdMultiCommand {
      * Default ctor.
      */
     public ObdMultiCommand() {
-        this.commands = new ArrayList<ObdCommand>();
+        this.commands = new ArrayList<>();
     }
 
     /**

--- a/src/main/java/com/github/pires/obd/commands/PersistentCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/PersistentCommand.java
@@ -15,8 +15,8 @@ import java.util.Map;
  */
 public abstract class PersistentCommand extends ObdCommand {
 
-    private static Map<String, String> knownValues = new HashMap<String, String>();
-    private static Map<String, ArrayList<Integer>> knownBuffers = new HashMap<String, ArrayList<Integer>>();
+    private static Map<String, String> knownValues = new HashMap<>();
+    private static Map<String, ArrayList<Integer>> knownBuffers = new HashMap<>();
 
     /**
      * <p>Constructor for PersistentCommand.</p>
@@ -40,8 +40,8 @@ public abstract class PersistentCommand extends ObdCommand {
      * <p>reset.</p>
      */
     public static void reset() {
-        knownValues = new HashMap<String, String>();
-        knownBuffers = new HashMap<String, ArrayList<Integer>>();
+        knownValues = new HashMap<>();
+        knownBuffers = new HashMap<>();
     }
 
     /**
@@ -61,7 +61,7 @@ public abstract class PersistentCommand extends ObdCommand {
         super.readResult(in);
         String key = getClass().getSimpleName();
         knownValues.put(key, rawData);
-        knownBuffers.put(key, new ArrayList<Integer>(buffer));
+        knownBuffers.put(key, new ArrayList<>(buffer));
     }
 
     /** {@inheritDoc} */

--- a/src/main/java/com/github/pires/obd/enums/FuelTrim.java
+++ b/src/main/java/com/github/pires/obd/enums/FuelTrim.java
@@ -17,7 +17,7 @@ public enum FuelTrim {
     LONG_TERM_BANK_2(0x09, "Long Term Fuel Trim Bank 2");
 
     /** Constant <code>map</code> */
-    private static Map<Integer, FuelTrim> map = new HashMap<Integer, FuelTrim>();
+    private static Map<Integer, FuelTrim> map = new HashMap<>();
 
     static {
         for (FuelTrim error : FuelTrim.values())

--- a/src/main/java/com/github/pires/obd/enums/FuelType.java
+++ b/src/main/java/com/github/pires/obd/enums/FuelType.java
@@ -35,7 +35,7 @@ public enum FuelType {
     HYBRID_REGENERATIVE(0x16, "Hybrid Regenerative");
 
     /** Constant <code>map</code> */
-    private static Map<Integer, FuelType> map = new HashMap<Integer, FuelType>();
+    private static Map<Integer, FuelType> map = new HashMap<>();
 
     static {
         for (FuelType error : FuelType.values())


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “ The diamond operator ("<>") should be used ”. You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.