### PR TITLE
Fixed not using the delay

### DIFF
--- a/src/main/java/com/github/pires/obd/commands/ObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/ObdCommand.java
@@ -94,7 +94,7 @@ public abstract class ObdCommand {
         // Carriage return
         out.write((cmd + "\r").getBytes());
         out.flush();
-
+        Thread.sleep(responseTimeDelay);
     }
 
     /**
@@ -108,6 +108,7 @@ public abstract class ObdCommand {
             InterruptedException {
         out.write("\r".getBytes());
         out.flush();
+        Thread.sleep(responseTimeDelay);
     }
 
     /**

--- a/src/main/java/com/github/pires/obd/commands/ObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/ObdCommand.java
@@ -31,7 +31,7 @@ public abstract class ObdCommand {
     protected String cmd = null;
     protected boolean useImperialUnits = false;
     protected String rawData = null;
-    protected long responseTimeDelay = 200;
+    protected Long responseDelayInMs = null;
     private long start;
     private long end;
 
@@ -94,7 +94,9 @@ public abstract class ObdCommand {
         // Carriage return
         out.write((cmd + "\r").getBytes());
         out.flush();
-        Thread.sleep(responseTimeDelay);
+        if (responseDelayInMs != null && responseDelayInMs > 0) {
+            Thread.sleep(responseDelayInMs);
+        }
     }
 
     /**
@@ -108,7 +110,9 @@ public abstract class ObdCommand {
             InterruptedException {
         out.write("\r".getBytes());
         out.flush();
-        Thread.sleep(responseTimeDelay);
+        if (responseDelayInMs != null && responseDelayInMs > 0) {
+            Thread.sleep(responseTimeDelay);
+        }
     }
 
     /**
@@ -285,19 +289,19 @@ public abstract class ObdCommand {
     /**
      * Time the command waits before returning from #sendCommand()
      *
-     * @return delay in ms
+     * @return delay in ms (may be null)
      */
-    public long getResponseTimeDelay() {
-        return responseTimeDelay;
+    public Long getResponseTimeDelay() {
+        return responseDelayInMs;
     }
 
     /**
      * Time the command waits before returning from #sendCommand()
      *
-     * @param responseTimeDelay a long.
+     * @param responseDelayInMs a Long (can be null)
      */
-    public void setResponseTimeDelay(long responseTimeDelay) {
-        this.responseTimeDelay = responseTimeDelay;
+    public void setResponseTimeDelay(Long responseDelayInMs) {
+        this.responseDelayInMs = responseDelayInMs;
     }
 
     //fixme resultunit

--- a/src/main/java/com/github/pires/obd/commands/ObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/ObdCommand.java
@@ -111,7 +111,7 @@ public abstract class ObdCommand {
         out.write("\r".getBytes());
         out.flush();
         if (responseDelayInMs != null && responseDelayInMs > 0) {
-            Thread.sleep(responseTimeDelay);
+            Thread.sleep(responseDelayInMs);
         }
     }
 


### PR DESCRIPTION
I've added in a sleep so that the ObdCommand class works as I *think* it was intended (I'm new to obd2 stuff so may be wrong). I haven't added tests yet as I'm unfamiliar with the testing framework, but I expect it would look something like the following?


```
    private int TEST_DELAY_MILLIS = 2000;

    /**
     * @throws Exception
     */
    @BeforeMethod
    public void setUp() throws Exception {
        command = new SpeedCommand();
        command.setResponseTimeDelay(TEST_DELAY_MILLIS);
    }

    /**
     * Test for valid InputStream read, 64km/h
     *
     * @throws IOException
     */
    @Test
    public void testValidSpeedMetric() throws IOException {
        
        OutputStream mockOut = createMock(OutputStream.class);
        
        long startTime = System.currentTimeMillis();
        
        command.sendCommand(mockOut);
        
        long timeTaken = System.currentTimeMillis() - startTime;

        boolean timeGreaterThanDelay = timeTaken > TEST_DELAY_MILLIS;

        assertEquals(timeGreaterThanDelay, true);
    }
```

If this is stupid or there is a better way, please let me know :)
