### PR TITLE
Adds method to the ObdCommand class to get the command's mode

### DIFF
--- a/src/main/java/com/github/pires/obd/commands/ObdCommand.java
+++ b/src/main/java/com/github/pires/obd/commands/ObdCommand.java
@@ -378,6 +378,19 @@ public abstract class ObdCommand {
         return cmd.substring(3);
     }
 
+    /**
+     * <p>getCommandMode.</p>
+     *
+     * @return a {@link java.lang.String} object.
+     */
+    public final String getCommandMode() {
+        if (cmd.length() >= 2) {
+            return cmd.substring(0, 2);
+        } else {
+            return cmd;
+        }
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;


### PR DESCRIPTION
We are using this library in a project for university and we require accessing the command's mode to store in a database. We added it locally but found this to be a useful feature that we wish to be incorporated in the main source.